### PR TITLE
phpコンテナに一般ユーザで入るよう追記

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
 
     php:
         build: ./docker/php
+        user: "1000:1000"
         volumes:
             - ./src:/var/www/
 


### PR DESCRIPTION
phpコンテナ内で一般ユーザとしてコマンドを使用。
artisanコマンドでファイル作成時、パーミッションの権限が一般ユーザにも付与されるようになる。
sudo chmod -R 777 src/*を打つ手間が省ける。